### PR TITLE
Assemble each markdown pass once, fixing overlapping delimiter matches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,32 @@
 All notable changes to this project are documented here. This project follows
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2.1.0
+
+### Fixed
+
+- A block quote containing a lone `_` renders as a block quote again. A single
+  underscore between spaces satisfies both the opening and the closing italics
+  pattern from the same character, so the matches overlap and three characters are
+  consumed where the delimiters alone account for four. The window bounds were
+  advanced by that predicted four, which left them a character behind the text for
+  every later pass, and the block quote pass then rejected its own closing match.
+  Inherited from 1.x.
+- The extra delimiters of a block quote are no longer left in the output in that
+  case. The failed triple match fell through to the single delimiter pass, which
+  consumed one `&gt;` and rendered the other two as text.
+
+If you depend on the previous rendering of a lone `_`, note that it is otherwise
+unchanged: it still produces an empty italics span.
+
+### Performance
+
+- A pass now reads the text as it was received, collects its replacements and
+  assembles the result once, instead of rebuilding the whole text around every
+  delimiter pair. Rebuilding cost time proportional to the length of the text for
+  every pair. On a message of 16,000 inline code spans this drops from 13s to
+  33ms; on 4,000, from 456ms to 8ms.
+
 ## 2.0.1
 
 No change in output. Verified byte-identical to 2.0.0 over the golden corpus and

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "slack-to-html",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "slack-to-html",
-      "version": "2.0.1",
+      "version": "2.1.0",
       "license": "MIT",
       "devDependencies": {
         "@arethetypeswrong/cli": "^0.18.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "slack-to-html",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "description": "Render Slack message markdown as HTML. Zero dependencies, TypeScript types included.",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/scripts/differentialFuzz.ts
+++ b/scripts/differentialFuzz.ts
@@ -20,8 +20,8 @@ import { join } from 'node:path'
 import { escapeForSlackWithMarkdown } from '../src/index.js'
 
 const REFERENCE_PATH = join(tmpdir(), 'slack-to-html-fuzz-reference.json')
-const CASE_COUNT = 4000
-const SEED = 20260728
+const CASE_COUNT = Number(process.env.FUZZ_CASES ?? 4000)
+const SEED = Number(process.env.FUZZ_SEED ?? 20260728)
 
 /** Deterministic PRNG, so both runs generate byte-identical inputs. */
 const mulberry32 = (seed: number) => () => {
@@ -103,14 +103,14 @@ if (process.argv[2] === 'capture') {
   writeFileSync(REFERENCE_PATH, JSON.stringify({ seed: SEED, inputs, outputs }), 'utf8')
   console.log(`Captured ${inputs.length} cases to ${REFERENCE_PATH}`)
 } else {
-  let reference: { inputs: string[]; outputs: string[] }
+  let reference: { seed: number; inputs: string[]; outputs: string[] }
   try {
     reference = JSON.parse(readFileSync(REFERENCE_PATH, 'utf8')) as typeof reference
   } catch {
     console.error(`No reference at ${REFERENCE_PATH}. Run "npm run fuzz:capture" first.`)
     process.exit(1)
   }
-  if (reference.inputs.length !== inputs.length) {
+  if (reference.inputs.length !== inputs.length || reference.seed !== SEED) {
     console.error('Reference was captured with different settings; recapture it.')
     process.exit(1)
   }

--- a/src/markdown.ts
+++ b/src/markdown.ts
@@ -33,11 +33,53 @@ interface ReplaceOptions {
   maxReplacements?: number
 }
 
-const incrementWindows = (windows: TagWindow[], offset: number): void => {
-  windows.forEach((tagWindow) => {
-    tagWindow[0] += offset
-    tagWindow[1] += offset
-  })
+/** A region of the text to rewrite, in the coordinates of the text read. */
+interface Replacement {
+  start: number
+  end: number
+  text: string
+}
+
+const applyReplacements = (text: string, replacements: Replacement[]): string => {
+  if (replacements.length === 0) {
+    return text
+  }
+  const parts: string[] = []
+  let position = 0
+  for (const replacement of replacements) {
+    parts.push(text.slice(position, replacement.start), replacement.text)
+    position = replacement.end
+  }
+  parts.push(text.slice(position))
+  return parts.join('')
+}
+
+/**
+ * Moves window bounds into the coordinates of the replaced text. A bound shifts
+ * by every replacement beginning before it, which holds a window truncated at a
+ * replacement's start in place while moving one that resumes after it.
+ *
+ * Replacements and windows are both in increasing order and windows never
+ * overlap, so the bounds are visited in increasing order and the replacements can
+ * be consumed in a single pass.
+ */
+const translateWindows = (windows: TagWindow[], replacements: Replacement[]): void => {
+  if (replacements.length === 0) {
+    return
+  }
+  let replacementIndex = 0
+  let shift = 0
+  for (const tagWindow of windows) {
+    for (const bound of [0, 1] as const) {
+      let pending = replacements[replacementIndex]
+      while (pending && pending.start < tagWindow[bound]) {
+        shift += pending.text.length - (pending.end - pending.start)
+        replacementIndex += 1
+        pending = replacements[replacementIndex]
+      }
+      tagWindow[bound] += shift
+    }
+  }
 }
 
 const replaceInWindows = (
@@ -68,7 +110,27 @@ const replaceInWindows = (
     ? buildClosingDelimiterRegExp(asymmetric, { escapeDelimiter: false })
     : buildClosingDelimiterRegExp(delimiterLiteral, { spacePadded })
 
-  let currentText = text
+  /*
+   * The text is read as it was received and rewritten once at the end, rather
+   * than rebuilt around every delimiter pair. This is safe because scanning
+   * always resumes at or after the end of the pair just matched, so no region
+   * still to be read is ever rewritten beforehand. Rebuilding in place cost time
+   * proportional to the length of the whole text for every pair, which on a text
+   * with many pairs outweighed everything else the pass does.
+   *
+   * Every position therefore stays in the coordinates of the text received,
+   * including the window bounds, which are moved into the coordinates of the
+   * result once the pass is finished. Keeping one coordinate system is also what
+   * fixes overlapping delimiter matches: the bounds used to be advanced by a
+   * predicted length change that was wrong when the opening and closing matches
+   * shared a character, leaving them out of step with the text for later passes.
+   */
+  const replacements: Replacement[] = []
+  const finish = (): ExpandedText => {
+    translateWindows(closedTagWindows, replacements)
+    return { text: applyReplacements(text, replacements), windows: closedTagWindows }
+  }
+
   let tagWindowIndex = 0
   let tagWindowOffset = 0
 
@@ -81,7 +143,7 @@ const replaceInWindows = (
    * Reuse is sound because `lastScan.match` is the first match at or after
    * `lastScan.from`: for any position in `[lastScan.from, lastScan.match.index]`
    * the answer is the same match, and a null result means there is no match after
-   * that position at all. The cache is dropped whenever the text changes.
+   * that position at all.
    */
   let lastScan: { from: number; match: RegExpExecArray | null } | null = null
 
@@ -89,7 +151,7 @@ const replaceInWindows = (
     if (lastScan && lastScan.from <= from && (!lastScan.match || lastScan.match.index >= from)) {
       return lastScan.match
     }
-    const match = execFrom(currentText, openingDelimiterRegExp, from)
+    const match = execFrom(text, openingDelimiterRegExp, from)
     lastScan = { from, match }
     return match
   }
@@ -99,7 +161,7 @@ const replaceInWindows = (
     // `maxReplacements: n` permits n + 1 replacements. Preserved from 1.x.
     const exhausted = maxReplacements !== undefined && maxReplacements < 0
     if (tagWindowIndex >= closedTagWindows.length || exhausted) {
-      return { text: currentText, windows: closedTagWindows }
+      return finish()
     }
 
     const currentClosedTagWindow = closedTagWindows[tagWindowIndex] as TagWindow
@@ -121,24 +183,24 @@ const replaceInWindows = (
       const closingDelimiterLength = asymmetric ? 0 : delimiterLiteral.length
       // Allow matching the end of the string if on the last window.
       const lastWindow =
-        tagWindowIndex === closedTagWindows.length - 1 && tagWindowEndIndex === currentText.length
+        tagWindowIndex === closedTagWindows.length - 1 && tagWindowEndIndex === text.length
       const closingMatchMaxIndex =
         (lastWindow ? tagWindowEndIndex + 1 : tagWindowEndIndex) - closingDelimiterLength + 1
 
       // Look ahead at the next index to greedily capture as much inside the
       // delimiters as possible.
       let closingMatch = execFrom(
-        currentText,
+        text,
         closingDelimiterRegExp,
         openingMatch.index + delimiterLiteral.length
       )
       let nextClosingMatch =
-        closingMatch && execFrom(currentText, closingDelimiterRegExp, closingMatch.index + 1)
+        closingMatch && execFrom(text, closingDelimiterRegExp, closingMatch.index + 1)
       while (closingMatch && nextClosingMatch) {
         // If the next match is still in the window and there is no whitespace in
         // between the two, use the later one.
         const nextWhitespace = execFrom(
-          currentText,
+          text,
           whitespaceRegExp,
           closingMatch.index + delimiterLiteral.length
         )
@@ -147,13 +209,11 @@ const replaceInWindows = (
           break
         }
         closingMatch = nextClosingMatch
-        nextClosingMatch = execFrom(currentText, closingDelimiterRegExp, closingMatch.index + 1)
+        nextClosingMatch = execFrom(text, closingDelimiterRegExp, closingMatch.index + 1)
       }
 
       if (closingMatch && closingMatch.index < closingMatchMaxIndex) {
         const afterDelimitersIndex = closingMatch.index + closingMatch[0].length
-        const textBeforeDelimiter = currentText.slice(0, openingMatch.index)
-        const textAfterDelimiter = currentText.slice(afterDelimitersIndex)
 
         const openingWhitespace = spacePadded
           ? (openingMatch.groups?.openingCapturedWhitespace ?? '')
@@ -166,7 +226,7 @@ const replaceInWindows = (
           asymmetric ? closingMatch[0] : ''
         }`
 
-        const textBetweenDelimiters = currentText.slice(
+        const textBetweenDelimiters = text.slice(
           openingMatch.index + openingMatch[0].length,
           closingMatch.index
         )
@@ -176,39 +236,29 @@ const replaceInWindows = (
 
         const replacedDelimiterText = `${openingReplacementString}${replacedTextBetweenDelimiters}${closingReplacementString}`
 
-        const delimiterReplacementLength = delimiterLiteral.length + closingDelimiterLength
-        const windowOffset =
-          replacementOpeningLiteral.length +
-          replacementClosingLiteral.length -
-          delimiterReplacementLength +
-          replacedTextBetweenDelimiters.length -
-          textBetweenDelimiters.length
-        const newUpperWindowLimit = tagWindowEndIndex + windowOffset
-
         const nextWindowIndex = partitionWindowOnMatch ? tagWindowIndex + 1 : tagWindowIndex
-        const nextTagWindowOffset = partitionWindowOnMatch
-          ? 0
-          : afterDelimitersIndex + windowOffset - tagWindowStartIndex + 1
 
         if (partitionWindowOnMatch) {
           // Split the current window into two around the delimiter pair.
           currentClosedTagWindow[1] = openingMatch.index
           closedTagWindows.splice(nextWindowIndex, 0, [
-            closingMatch.index + closingDelimiterLength + windowOffset,
-            newUpperWindowLimit,
+            closingMatch.index + closingDelimiterLength,
+            tagWindowEndIndex,
           ])
-        } else {
-          currentClosedTagWindow[1] = newUpperWindowLimit
         }
-        incrementWindows(closedTagWindows.slice(nextWindowIndex + 1), windowOffset)
         if (maxReplacements !== undefined) {
           maxReplacements -= 1
         }
 
-        currentText = `${textBeforeDelimiter}${replacedDelimiterText}${textAfterDelimiter}`
-        lastScan = null
+        replacements.push({
+          start: openingMatch.index,
+          end: afterDelimitersIndex,
+          text: replacedDelimiterText,
+        })
         tagWindowIndex = nextWindowIndex
-        tagWindowOffset = nextTagWindowOffset
+        tagWindowOffset = partitionWindowOnMatch
+          ? 0
+          : afterDelimitersIndex + 1 - tagWindowStartIndex
         continue
       }
     }

--- a/test/markdown.test.ts
+++ b/test/markdown.test.ts
@@ -149,23 +149,34 @@ describe('markdown', () => {
 
     /*
      * A single underscore between spaces satisfies both the opening and the
-     * closing pattern from the same character, so the two matches overlap. 1.x
-     * emits an empty italics span for it and, because it then advances its window
-     * bounds by one character less than the text actually grew, every later pass
-     * sees bounds that no longer line up with the text. The visible effect is that
-     * a block quote containing a lone underscore is not rendered as one at all.
-     *
-     * Recorded here because it is inherited behavior rather than something aimed
-     * at, and because a change to the offset arithmetic silently alters it.
+     * closing pattern from the same character, so the matches overlap and three
+     * characters are consumed where the delimiters alone account for four. Up to
+     * 2.0.1 the window bounds were advanced by that predicted four, which left
+     * them a character behind the text for every later pass. The visible effect
+     * was that a block quote containing a lone underscore did not render as one.
      */
-    it('renders a lone italics delimiter as an empty span, suppressing an enclosing block quote', () => {
+    it('renders a lone italics delimiter as an empty span', () => {
       expect(escapeForSlackWithMarkdown('a _ b')).toBe('a <span class="slack_italics"></span> b')
+    })
+
+    it('renders a block quote containing a lone italics delimiter', () => {
       expect(escapeForSlackWithMarkdown('&gt;&gt;&gt;a _ b')).toBe(
-        '&gt;&gt;&gt;a <span class="slack_italics"></span> b'
+        '<div class="slack_block">a <span class="slack_italics"></span> b</div>'
       )
-      // Without the lone underscore the same input is a block quote.
+      expect(escapeForSlackWithMarkdown('&gt;a _ b')).toBe(
+        '<span class="slack_block">a <span class="slack_italics"></span> b</span>'
+      )
+      // The same input without the lone underscore, which always worked.
       expect(escapeForSlackWithMarkdown('&gt;&gt;&gt;a b')).toBe(
         '<div class="slack_block">a b</div>'
+      )
+    })
+
+    it('does not leave the delimiters of a block quote in the output', () => {
+      // The failed triple match fell through to the single delimiter pass, which
+      // consumed one `&gt;` and left the other two behind as text.
+      expect(escapeForSlackWithMarkdown('&gt;&gt;&gt;quoted\t_')).toBe(
+        '<div class="slack_block">quoted\t<span class="slack_italics"></span></div>'
       )
     })
   })

--- a/test/performance.test.ts
+++ b/test/performance.test.ts
@@ -44,4 +44,15 @@ describe('performance', () => {
     escapeForSlackWithMarkdown(input)
     expect(performance.now() - started).toBeLessThan(200)
   })
+
+  it('does not cost time proportional to the text for every delimiter pair', () => {
+    // 8,000 spans took about 2.8s while the text was rebuilt around every pair,
+    // and 16,000 took 13s. Both are well inside this bound once the text is
+    // assembled once per pass, and the bound is loose enough for shared CI
+    // machines while still failing if the quadratic behavior returns.
+    const input = `${'`c` '.repeat(16000)}end`
+    const started = performance.now()
+    escapeForSlackWithMarkdown(input)
+    expect(performance.now() - started).toBeLessThan(1000)
+  })
 })


### PR DESCRIPTION
Releases as **2.1.0**. Contains one deliberate rendering change, described below, and removes the last quadratic term from the markdown passes. The two are the same change: the bug exists because the pass predicted a length instead of measuring it, and the fix is to stop needing the prediction.

## The bug

A lone `_` between spaces satisfies both the opening and the closing italics pattern **from the same character**, so the two matches overlap. Three characters are consumed, `' _ '`, where the delimiters alone account for four. The pass advanced its window bounds by that predicted four:

```
pass '_': region=[13,16) consumed=3 emitted=37 actualTextDelta=34 windowOffsetApplied=33
       -> windowEnd=50 textLength=51
```

The bounds end up a character behind the text, so every later pass reads bounds that no longer line up with what it is scanning. The block quote pass sees a last window that no longer ends at the end of the text, rejects its own `$` closing match, and renders nothing. It then falls through to the single delimiter pass, which consumes one `&gt;` and leaves the other two in the output as text.

| input | 2.0.1 | this branch |
| --- | --- | --- |
| `&gt;&gt;&gt;a _ b` | `&gt;&gt;&gt;a <span class="slack_italics"></span> b` | `<div class="slack_block">a <span class="slack_italics"></span> b</div>` |
| `&gt;\t_` | `&gt;\t<span class="slack_italics"></span>` | `<span class="slack_block">\t<span class="slack_italics"></span></span>` |

Inherited from 1.x. A lone `_` still renders as an empty italics span, which is unchanged; only the effect on an enclosing block quote differs.

## The change

A pass now reads the text as it was received, collects its replacements, and assembles the result once, so every position stays in one coordinate system and the window bounds are moved into the coordinates of the result once the pass is done. Nothing predicts a length any more.

This is sound because scanning always resumes at or after the end of the pair just matched, so no region still to be read is ever rewritten beforehand. That holds for all three shapes the passes use: the partitioning passes resume at the start of the window they just created, and the others resume one character past the pair.

It also removes the last quadratic term. Rebuilding the text around every pair cost time proportional to the length of the whole text each time, which is easy to mismeasure because `before + replaced + after` is a lazy rope in V8 and the real cost is in the `slice` calls that flatten it.

| inline code spans | 2.0.1 | this branch | faster by |
| --- | --- | --- | --- |
| 1,000 | 13.3ms | 5.5ms | 2x |
| 2,000 | 36.2ms | 4.8ms | 7x |
| 4,000 | 455.6ms | 8.3ms | 55x |
| 8,000 | 2,828.9ms | 21.5ms | 132x |
| 16,000 | 13,085.9ms | 32.7ms | 401x |

Measured in one process against `master`'s implementation, so the two columns are directly comparable. Growth is now roughly 2x per doubling of the input.

## How the behavior change was bounded

`npm run fuzz:compare` over **40,000 generated inputs** reports exactly **4** differences, and all four are the same case: a trailing lone `_` inside a block quote. That is the evidence that the change is limited to what is described above and nothing else moved. The golden corpus is unaffected, so 1.x parity elsewhere is intact.

The harness now takes `FUZZ_CASES` and `FUZZ_SEED`, which is how the sweep was widened from the default 4,000.

## Test plan

- [x] 229 tests pass, including the golden corpus
- [x] 40,000-case differential sweep: 4 differences, all the intended case
- [x] Tests updated to assert the fixed rendering, with the cause recorded
- [x] Perf test added that fails if the quadratic behavior returns
- [x] lint, typecheck, format check, build, `publint`, `attw`
- [ ] CI green

Made with [Cursor](https://cursor.com)